### PR TITLE
Added Multi-line parsing of functions

### DIFF
--- a/line-by-line.py
+++ b/line-by-line.py
@@ -131,9 +131,13 @@ class RDocsCommand(sublime_plugin.TextCommand):
         ### take out anything like ifelse() or c()
         params_txt=re.sub('=[^=]+?\(\S+?\),', ",", params_txt)
         params_txt=re.sub('=[^=]+?\{\S+?\},', ",", params_txt)
-        params_txt=re.sub(',$', "", params_txt)
+        # params_txt=re.sub(',$', "", params_txt)
 
+        # params_txt=re.sub('#*(.*),*(.*)\n', "\\1;\\2", params_txt)
 
+        params_txt=re.sub('(.*), *[#]*(.*)', "\\1 #\\2,", params_txt)
+        params_txt=re.sub('\n', " ", params_txt)
+        # self.view.insert(edit, sel.begin(), params_txt)
 
         # Splitting on commas
         params = params_txt.split(',')
@@ -144,8 +148,11 @@ class RDocsCommand(sublime_plugin.TextCommand):
 
             # Added if statement if not empty
             if p != '':
-                p = re.sub('(.*)=(.*)', "\\1", p)
-                snippet += "#' @param %s <what param does>\n" % p
+                p = re.sub('(.*)=(.*)\s*#\s*(.*)', "\\1 \\3", p);
+                p = re.sub("^\s*","",p)
+                p = re.sub("#*","",p)
+                p = re.sub('(.*)=(.*)', "\\1", p);
+                snippet += "#' @param %s\n" % p
 
         snippet += "#' @export\n#' @keywords\n#' @seealso\n#' @return\n#' @alias\n#' @examples \dontrun{\n#'\n#'}\n"
 

--- a/line-by-line.py
+++ b/line-by-line.py
@@ -106,11 +106,15 @@ class SendSelectCommand(sublime_plugin.TextCommand):
 
 class RDocsCommand(sublime_plugin.TextCommand):
     def run(self, edit):
+        # self.view.insert(edit, 1, self.view.sel()[0])
         sel = self.view.sel()[0]
         # Taking out spaces and such
-        params_reg = self.view.find('(?<=\().*(?=\)|$)', sel.begin())
+        # params_reg = self.view.find('(?<=\().*(?=\)|$)', sel.begin())
         # self.view.insert(edit, sel.begin(), params_reg)
-        params_txt = self.view.substr(params_reg)
+        params_txt = ''
+        for i in self.view.sel():
+            params_txt += ' ' + self.view.substr(i)
+        params_txt=re.sub(".*function\s*\(","",params_txt)
         params_txt=re.sub("^\s+","",params_txt)
         params_txt=re.sub("\s+\Z","",params_txt)
         params_txt=re.sub(',\s+', ",", params_txt)

--- a/line-by-line.py
+++ b/line-by-line.py
@@ -112,18 +112,47 @@ class RDocsCommand(sublime_plugin.TextCommand):
         # params_reg = self.view.find('(?<=\().*(?=\)|$)', sel.begin())
         # self.view.insert(edit, sel.begin(), params_reg)
         params_txt = ''
-        for i in self.view.sel():
-            params_txt += ' ' + self.view.substr(i)
+        pp = self.view.substr(sel).split('\n')
+        for i in pp:
+            p = re.sub("#+", "#", i)
+            p1 = re.sub("([^#]+)#.*", "\\1", p)
+            p2 = re.sub("([^#]+)#(.*)", "# \\2", p)
+            if not re.search("#", p):
+                p2 = '';
+            p2 = re.sub("[^#]+[#|$]", "", p2)
+            p2 = re.sub(",", " ", p2)
+
+            p2 = re.sub("=", " ISEQUALTOVALUETHIS ", p2)
+            p1 = re.sub("(.*)=(.*)", "\\1", p1)
+            # p1 = re.sub("#.*", "", p)
+            # self.view.insert(edit, sel.begin(), p1)
+
+            p2=re.sub("\s+"," ",p2)
+            p2=re.sub("^\s+"," ",p2)
+            p2=re.sub("\s+\Z","",p2)
+            p1 = re.sub("(.*),", "\\1 ", p1)
+            # self.view.insert(edit, sel.begin(), p2)
+            # if p2 != '':
+            p = p1 + p2 + ","
+            # else :
+                # p = p1
+            # p = re.sub('(.*)#(.*)[,](.*)', "\\1#\\2 \\3", p)
+            params_txt += ' ' + p
+
+
         params_txt=re.sub(".*function\s*\(","",params_txt)
         params_txt=re.sub("^\s+","",params_txt)
         params_txt=re.sub("\s+\Z","",params_txt)
         params_txt=re.sub(',\s+', ",", params_txt)
         params_txt=re.sub('\s+=', "=", params_txt)
         params_txt=re.sub('=\s+', "=", params_txt)
+        params_txt=re.sub('\s+', " ", params_txt)
         params_txt=re.sub('"', "", params_txt)
         params_txt=re.sub(',$', "", params_txt)
         params_txt=re.sub('{$', "", params_txt)
         params_txt=re.sub('\)$', "", params_txt)
+        params_txt=re.sub('^,', "", params_txt)
+        params_txt=re.sub(',#', " #", params_txt)
 
         #### adding trailing , so they are the same
         params_txt = params_txt + ","
@@ -139,6 +168,7 @@ class RDocsCommand(sublime_plugin.TextCommand):
         params_txt=re.sub('\n', " ", params_txt)
         # self.view.insert(edit, sel.begin(), params_txt)
 
+
         # Splitting on commas
         params = params_txt.split(',')
         snippet = "#' @title <brief desc>\n#'\n#' @description <full description>\n"
@@ -148,10 +178,12 @@ class RDocsCommand(sublime_plugin.TextCommand):
 
             # Added if statement if not empty
             if p != '':
-                p = re.sub('(.*)=(.*)\s*#\s*(.*)', "\\1 \\3", p);
+                p = re.sub('(.*)=(.*)\s*,\s*#\s*(.*)', "\\1 \\3", p);
                 p = re.sub("^\s*","",p)
-                p = re.sub("#*","",p)
+                p = re.sub("#+"," ",p)
                 p = re.sub('(.*)=(.*)', "\\1", p);
+                p = re.sub("\s+"," ",p)
+                p = re.sub("ISEQUALTOVALUETHIS", "=", p)
                 snippet += "#' @param %s\n" % p
 
         snippet += "#' @export\n#' @keywords\n#' @seealso\n#' @return\n#' @alias\n#' @examples \dontrun{\n#'\n#'}\n"


### PR DESCRIPTION
This makes the code less robust in that you have to select only function code, but you can do multi-line parsing.

Now you can have something like 
fslsmooth <- function(
  file,
  sigma=10, 
  mask=NULL, 
  outfile=NULL, 
  retimg = FALSE,
  reorient = FALSE,
  intern=TRUE){

and will parse to 
# ' @export
# ' @title <brief desc>
# '
# ' @description <full description>
# ' @param file <what param does>
# ' @param sigma <what param does>
# ' @param mask <what param does>
# ' @param outfile <what param does>
# ' @param retimg <what param does>
# ' @param reorient <what param does>
# ' @param intern <what param does>
# ' @export
# ' @keywords
# ' @seealso
# ' @return
# ' @alias
# ' @examples \dontrun{
# '
# '}
